### PR TITLE
I updated gui.py to eliminate Qt5 dependency (now a more urgent issue with latest version 23.10)

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1,4 +1,3 @@
-from PyQt5 import QtCore
 from aqt import mw as window, utils, qt, addons
 import aqt
 from . import templates
@@ -15,7 +14,7 @@ def _help():
         with open(file, "r", encoding="utf-8") as f:
             doc = f.read()
         box = aqt.QMessageBox(window)
-        box.setTextFormat(QtCore.Qt.MarkdownText)
+        box.setTextFormat(qt.Qt.TextFormat.MarkdownText)
         box.setText(doc)
         box.exec()
     else:


### PR DESCRIPTION
Updated gui.py to remove import from PyQt5. Changes were based on:

https://forums.ankiweb.net/t/porting-tips-for-anki-23-10/35916
* Qt5 compatibility now off by default in Anki 23.10
* enums must be prefixed with their type name

https://addon-docs.ankiweb.net/qt.html
* if importing Qt classes from aqt.qt, the code should still work in Qt5

Tested by verifying that README.md displays correctly via Tools → Import / Export templates → Help / Guide. Tested with Anki 2.1.66 and 23.10 using Qt6, on Windows 11.

Edit: later also tested with Anki 2.1.50, 2.1.61, 2.1.66, and 23.10 using Qt5, on Windows 10. See second comment below.
